### PR TITLE
Move RHEL7 and Centos7 dockerfiles to right folder, because go-toolse…

### DIFF
--- a/1.10/Dockerfile
+++ b/1.10/Dockerfile
@@ -1,8 +1,8 @@
-FROM rhscl/s2i-base-rhel7:1
+FROM centos/s2i-base-centos7
 
 ENV NAME=golang \
-    VERSION=1.8
- 
+    VERSION=1.10
+
 ENV SUMMARY="Platform for building and running Go $VERSION based applications" \
     DESCRIPTION="Go $VERSION available as docker container is a base platform for \
 building and running various Go $VERSION applications and frameworks. \
@@ -14,16 +14,14 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="Go $VERSION" \
       io.openshift.tags="builder,golang,golang18,rh-golang18,go" \
-      com.redhat.component="go-toolset-7-docker" \
-      name="devtools/go-toolset-7-rhel7" \
+      com.redhat.component="go-toolset-7" \
+      name="centos/go-toolset-7-centos7" \
       version="1" \
-      usage="docker run devtools/go-toolset-7-rhel7"
+      maintainer="Jakub Čajka <jcajka@redhat.com>" \
+      usage="docker run centos/go-toolset-7-centos7"
 
-RUN yum install -y yum-utils && \
-    yum-config-manager --disable \* &> /dev/null && \
-    yum-config-manager --enable rhel-7-server-devtools-rpms && \
-    yum-config-manager --enable rhel-7-server-rpms && \
-    yum-config-manager --enable rhel-7-server-optional-rpms && \
+RUN yum install -y centos-release-scl-rh && \
+    yum-config-manager --enable centos-sclo-rh-testing && \
     INSTALL_PKGS="go-toolset-7" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/1.10/Dockerfile.rhel7
+++ b/1.10/Dockerfile.rhel7
@@ -1,8 +1,8 @@
-FROM centos/s2i-base-centos7
+FROM rhscl/s2i-base-rhel7:1
 
 ENV NAME=golang \
-    VERSION=1.8 
-
+    VERSION=1.10
+ 
 ENV SUMMARY="Platform for building and running Go $VERSION based applications" \
     DESCRIPTION="Go $VERSION available as docker container is a base platform for \
 building and running various Go $VERSION applications and frameworks. \
@@ -14,14 +14,16 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="Go $VERSION" \
       io.openshift.tags="builder,golang,golang18,rh-golang18,go" \
-      com.redhat.component="go-toolset-7" \
-      name="centos/go-toolset-7-centos7" \
+      com.redhat.component="go-toolset-7-docker" \
+      name="devtools/go-toolset-7-rhel7" \
       version="1" \
-      maintainer="Jakub Čajka <jcajka@redhat.com>" \
-      usage="docker run centos/go-toolset-7-centos7"
+      usage="docker run devtools/go-toolset-7-rhel7"
 
-RUN yum install -y centos-release-scl-rh && \
-    yum-config-manager --enable centos-sclo-rh-testing && \
+RUN yum install -y yum-utils && \
+    yum-config-manager --disable \* &> /dev/null && \
+    yum-config-manager --enable rhel-7-server-devtools-rpms && \
+    yum-config-manager --enable rhel-7-server-rpms && \
+    yum-config-manager --enable rhel-7-server-optional-rpms && \
     INSTALL_PKGS="go-toolset-7" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
Move RHEL7 and Centos7 dockerfiles to right folder, because go-toolset-7-golang were updated to 1.10

+ update common/ submodule

Fixes: #7 