### PR TITLE
Fedora OSBS is now managing the release label, so remove it

### DIFF
--- a/1.10/Dockerfile.fedora
+++ b/1.10/Dockerfile.fedora
@@ -2,7 +2,6 @@ FROM registry.fedoraproject.org/f28/s2i-base:latest
 
 ENV NAME=golang \
     VERSION=1.10 \
-    RELEASE=1 \
     ARCH=x86_64
 
 ENV SUMMARY="Platform for building and running Go $VERSION based applications" \
@@ -19,7 +18,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \
-      release="$RELEASE.$DISTTAG" \
       architecture="$ARCH" \
       maintainer="Jakub Čajka <jcajka@redhat.com>" \
       usage="docker run $FGC/$NAME"

--- a/1.8/Dockerfile.fedora
+++ b/1.8/Dockerfile.fedora
@@ -2,7 +2,6 @@ FROM registry.fedoraproject.org/f26/s2i-base:latest
 
 ENV NAME=golang \
     VERSION=1.8 \
-    RELEASE=1 \
     ARCH=x86_64
 
 ENV SUMMARY="Platform for building and running Go $VERSION based applications" \
@@ -19,7 +18,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \
-      release="$RELEASE.$DISTTAG" \
       architecture="$ARCH" \
       maintainer="Jakub Čajka <jcajka@redhat.com>" \
       usage="docker run $FGC/$NAME"

--- a/1.9/Dockerfile.fedora
+++ b/1.9/Dockerfile.fedora
@@ -2,7 +2,6 @@ FROM registry.fedoraproject.org/f27/s2i-base:latest
 
 ENV NAME=golang \
     VERSION=1.9 \
-    RELEASE=1 \
     ARCH=x86_64
 
 ENV SUMMARY="Platform for building and running Go $VERSION based applications" \
@@ -19,7 +18,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \
-      release="$RELEASE.$DISTTAG" \
       architecture="$ARCH" \
       maintainer="Jakub Čajka <jcajka@redhat.com>" \
       usage="docker run $FGC/$NAME"


### PR DESCRIPTION
Fedora OSBS is now managing the release label, so remove it, otherwise the images will not build there https://koji.fedoraproject.org/koji/taskinfo?taskID=29598580 .