### PR TITLE
Fix up Fedora container so they build in the OSBS

### DIFF
--- a/1.10/Dockerfile.fedora
+++ b/1.10/Dockerfile.fedora
@@ -19,7 +19,7 @@ LABEL summary="$SUMMARY" \
       name="$FGC/$NAME" \
       version="$VERSION" \
       architecture="$ARCH" \
-      maintainer="Jakub Čajka <jcajka@redhat.com>" \
+      maintainer="Jakub Cajka <jcajka@fedoraproject.org>" \
       usage="docker run $FGC/$NAME"
 
 RUN INSTALL_PKGS="golang" && \

--- a/1.11/Dockerfile.fedora
+++ b/1.11/Dockerfile.fedora
@@ -19,7 +19,7 @@ LABEL summary="$SUMMARY" \
       name="$FGC/$NAME" \
       version="$VERSION" \
       architecture="$ARCH" \
-      maintainer="Jakub Čajka <jcajka@redhat.com>" \
+      maintainer="Jakub Cajka <jcajka@fedoraproject.org>" \
       usage="docker run $FGC/$NAME"
 
 RUN INSTALL_PKGS="golang" && \

--- a/1.8/Dockerfile.fedora
+++ b/1.8/Dockerfile.fedora
@@ -19,7 +19,7 @@ LABEL summary="$SUMMARY" \
       name="$FGC/$NAME" \
       version="$VERSION" \
       architecture="$ARCH" \
-      maintainer="Jakub Čajka <jcajka@redhat.com>" \
+      maintainer="Jakub Cajka <jcajka@fedoraproject.org>" \
       usage="docker run $FGC/$NAME"
 
 RUN INSTALL_PKGS="golang" && \

--- a/1.9/Dockerfile.fedora
+++ b/1.9/Dockerfile.fedora
@@ -19,7 +19,7 @@ LABEL summary="$SUMMARY" \
       name="$FGC/$NAME" \
       version="$VERSION" \
       architecture="$ARCH" \
-      maintainer="Jakub Čajka <jcajka@redhat.com>" \
+      maintainer="Jakub Cajka <jcajka@fedoraproject.org>" \
       usage="docker run $FGC/$NAME"
 
 RUN INSTALL_PKGS="golang" && \

--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ Usage
 ---------------------------------
 
 For information about usage of Dockerfile for Golang Toolset 7 and Fedora golang,
-see usage documentation for respective Go versions [Go1.8](1.8/README.md) [Go1.9](1.9/README.md) [Go1.10](1.10/README.md).
+see usage documentation for respective Go versions [Go1.8](1.8/README.md) [Go1.9](1.9/README.md) [Go1.10](1.10/README.md) [Go1.11](1.11/README.md).
 


### PR DESCRIPTION
Remove UTF-8 chars from fedora dockerfiles due to https://github.com/projectatomic/atomic-reactor/issues/1072 
Mention 1.11 in the top level README