### PR TITLE
Update numbering to better matter actual backing image

### DIFF
--- a/imagestreams/golang-centos7.json
+++ b/imagestreams/golang-centos7.json
@@ -11,7 +11,7 @@
         "tags": [
             {
                 "annotations": {
-                    "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/8/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major versions updates.",
+                    "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Go available on OpenShift, including major version updates.",
                     "iconClass": "icon-go-gopher",
                     "openshift.io/display-name": "Go (Latest)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -21,7 +21,7 @@
                 },
                 "from": {
                     "kind": "ImageStreamTag",
-                    "name": "1.8"
+                    "name": "1"
                 },
                 "name": "latest",
                 "referencePolicy": {
@@ -30,19 +30,19 @@
             },
             {
                 "annotations": {
-                  "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/8/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major versions updates.",
-                  "iconClass": "icon-go-gopher",
-                  "openshift.io/display-name": "Go (1.8)",
-                  "openshift.io/provider-display-name": "Red Hat, Inc.",
-                  "sampleRepo": "https://github.com/sclorg/golang-ex.git",
-                  "supports": "golang",
-                  "tags": "builder,golang,go"
+                    "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/8/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Go associated with this tag available on OpenShift, including minor version updates.",
+                    "iconClass": "icon-go-gopher",
+                    "openshift.io/display-name": "Go (1.x)",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "sampleRepo": "https://github.com/sclorg/golang-ex.git",
+                    "supports": "golang",
+                    "tags": "builder,golang,go"
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "docker.io/centos/go-toolset-7-centos7:latest"
+                    "name": "docker.io/centos/go-toolset-7-centos7:1"
                 },
-                "name": "1.8",
+                "name": "1",
                 "referencePolicy": {
                     "type": "Local"
                 }


### PR DESCRIPTION
Says 1.8 but really is tracking to `:1` tag, so changed to `1.x` to better match the current structure of the underlying image