### PR TITLE
Correct Nodejs Typo in Description for Centos Image Stream

### DIFF
--- a/imagestreams/golang-centos7.json
+++ b/imagestreams/golang-centos7.json
@@ -11,7 +11,7 @@
         "tags": [
             {
                 "annotations": {
-                    "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/8/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Go available on OpenShift, including major versions updates.",
+                    "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Go available on OpenShift, including major versions updates.",
                     "iconClass": "icon-go-gopher",
                     "openshift.io/display-name": "Go (Latest)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -30,7 +30,7 @@
             },
             {
                 "annotations": {
-                  "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/8/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Go available on OpenShift, including major versions updates.",
+                  "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Go available on OpenShift, including major versions updates.",
                   "iconClass": "icon-go-gopher",
                   "openshift.io/display-name": "Go (1.8)",
                   "openshift.io/provider-display-name": "Red Hat, Inc.",

--- a/imagestreams/golang-centos7.json
+++ b/imagestreams/golang-centos7.json
@@ -11,7 +11,7 @@
         "tags": [
             {
                 "annotations": {
-                    "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/8/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major versions updates.",
+                    "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/8/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Go available on OpenShift, including major versions updates.",
                     "iconClass": "icon-go-gopher",
                     "openshift.io/display-name": "Go (Latest)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -30,7 +30,7 @@
             },
             {
                 "annotations": {
-                  "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/8/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major versions updates.",
+                  "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/8/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Go available on OpenShift, including major versions updates.",
                   "iconClass": "icon-go-gopher",
                   "openshift.io/display-name": "Go (1.8)",
                   "openshift.io/provider-display-name": "Red Hat, Inc.",


### PR DESCRIPTION
This pull request corrects a small typo in the annotation descriptions for the CentOS image stream. It changes `Nodejs` to `Go` and updates the `README` links from the `Nodejs s2i` `README` to the `Go s2i` `README`. 