### PR TITLE
Update READMEs to Match go Versions and Update CentOS to 1.10.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ coverage.xml
 # Translations
 *.mo
 *.pot
+
+#macOS
+.DS_Store

--- a/imagestreams/golang-centos7.json
+++ b/imagestreams/golang-centos7.json
@@ -10,8 +10,9 @@
     "spec": {
         "tags": [
             {
+                "name": "latest",
                 "annotations": {
-                    "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Go available on OpenShift, including major versions updates.",
+                    "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/1.10/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Go available on OpenShift, including major versions updates.",
                     "iconClass": "icon-go-gopher",
                     "openshift.io/display-name": "Go (Latest)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -21,18 +22,18 @@
                 },
                 "from": {
                     "kind": "ImageStreamTag",
-                    "name": "1.8"
+                    "name": "1.10.2"
                 },
-                "name": "latest",
                 "referencePolicy": {
                     "type": "Local"
                 }
             },
             {
+                "name": "1.10.2",
                 "annotations": {
-                  "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Go available on OpenShift, including major versions updates.",
+                  "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/1.10/README.md.",
                   "iconClass": "icon-go-gopher",
-                  "openshift.io/display-name": "Go (1.8)",
+                  "openshift.io/display-name": "Go 1.10.2",
                   "openshift.io/provider-display-name": "Red Hat, Inc.",
                   "sampleRepo": "https://github.com/sclorg/golang-ex.git",
                   "supports": "golang",
@@ -42,7 +43,6 @@
                     "kind": "DockerImage",
                     "name": "docker.io/centos/go-toolset-7-centos7:latest"
                 },
-                "name": "1.8",
                 "referencePolicy": {
                     "type": "Local"
                 }

--- a/imagestreams/golang-rhel7.json
+++ b/imagestreams/golang-rhel7.json
@@ -10,8 +10,9 @@
     "spec": {
         "tags": [
             {
+                "name": "latest",
                 "annotations": {
-                    "description": "Build and run Go applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Go available on OpenShift, including major version updates.",
+                    "description": "Build and run Go applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/1.11/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Go available on OpenShift, including major version updates.",
                     "iconClass": "icon-go-gopher",
                     "openshift.io/display-name": "Go (Latest)",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -23,16 +24,16 @@
                     "kind": "ImageStreamTag",
                     "name": "1.11.5"
                 },
-                "name": "latest",
                 "referencePolicy": {
                     "type": "Local"
                 }
             },
             {
+                "name": "1.11.5",
                 "annotations": {
-                  "description": "Build and run Go applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Go available on OpenShift, including major version updates.",
+                  "description": "Build and run Go applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/1.11/README.md",
                   "iconClass": "icon-go-gopher",
-                  "openshift.io/display-name": "Go (1.11.5)",
+                  "openshift.io/display-name": "Go 1.11.5",
                   "openshift.io/provider-display-name": "Red Hat, Inc.",
                   "sampleRepo": "https://github.com/sclorg/golang-ex.git",
                   "supports": "golang",
@@ -42,7 +43,6 @@
                     "kind": "DockerImage",
                     "name": "registry.redhat.io/devtools/go-toolset-rhel7:1.11.5"
                 },
-                "name": "1.11.5",
                 "referencePolicy": {
                     "type": "Local"
                 }


### PR DESCRIPTION
Currently, the image stream for CentOS lists its go version as 1.8. However, the image associated with the stream is version 1.10.2. This pull request clarifies that the image stream uses 1.10.2.

This pull request also reformats the image streams to match the format of other image streams under `sclorg`. Additionally, READMEs in descriptions have been updated to match the appropriate READMEs associated with particular versions. 