### PR TITLE
Update imagestreams for RHEL 8.5 and RHSCL 3.8

### DIFF
--- a/imagestreams/golang-centos.json
+++ b/imagestreams/golang-centos.json
@@ -21,7 +21,7 @@
                 },
                 "from": {
                     "kind": "ImageStreamTag",
-                    "name": "1.13.4-ubi8"
+                    "name": "1.16.7-ubi8"
                 },
                 "name": "latest",
                 "referencePolicy": {
@@ -32,7 +32,7 @@
                 "annotations": {
                   "description": "Build and run Go applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.",
                   "iconClass": "icon-go-gopher",
-                  "openshift.io/display-name": "Go 1.13.4 (UBI 8)",
+                  "openshift.io/display-name": "Go 1.16.7 (UBI 8)",
                   "openshift.io/provider-display-name": "Red Hat, Inc.",
                   "sampleRepo": "https://github.com/sclorg/golang-ex.git",
                   "supports": "golang",
@@ -40,9 +40,9 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/ubi8/go-toolset:1.13.4"
+                    "name": "registry.access.redhat.com/ubi8/go-toolset:1.16.7"
                 },
-                "name": "1.13.4-ubi8",
+                "name": "1.16.7-ubi8",
                 "referencePolicy": {
                     "type": "Local"
                 }
@@ -51,7 +51,7 @@
                 "annotations": {
                   "description": "Build and run Go applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.",
                   "iconClass": "icon-go-gopher",
-                  "openshift.io/display-name": "Go 1.13.4 (UBI 7)",
+                  "openshift.io/display-name": "Go 1.16.7 (UBI 7)",
                   "openshift.io/provider-display-name": "Red Hat, Inc.",
                   "sampleRepo": "https://github.com/sclorg/golang-ex.git",
                   "supports": "golang",
@@ -59,9 +59,9 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/ubi7/go-toolset:1.13.4"
+                    "name": "registry.access.redhat.com/ubi7/go-toolset:1.16.7"
                 },
-                "name": "1.13.4-ubi7",
+                "name": "1.16.7-ubi7",
                 "referencePolicy": {
                     "type": "Local"
                 }

--- a/imagestreams/golang-centos.json
+++ b/imagestreams/golang-centos.json
@@ -1,5 +1,5 @@
 {
-    "apiVersion": "v1",
+    "apiVersion": "image.openshift.io/v1",
     "kind": "ImageStream",
     "metadata": {
         "annotations": {

--- a/imagestreams/golang-rhel-aarch64.json
+++ b/imagestreams/golang-rhel-aarch64.json
@@ -21,7 +21,7 @@
                 },
                 "from": {
                     "kind": "ImageStreamTag",
-                    "name": "1.14.7-ubi8"
+                    "name": "1.16.7-ubi8"
                 },
                 "name": "latest",
                 "referencePolicy": {
@@ -32,7 +32,7 @@
                 "annotations": {
                   "description": "Build and run Go applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.",
                   "iconClass": "icon-go-gopher",
-                  "openshift.io/display-name": "Go 1.14.7 (UBI 8)",
+                  "openshift.io/display-name": "Go 1.16.7 (UBI 8)",
                   "openshift.io/provider-display-name": "Red Hat, Inc.",
                   "sampleRepo": "https://github.com/sclorg/golang-ex.git",
                   "supports": "golang",
@@ -40,9 +40,9 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.redhat.io/ubi8/go-toolset:1.14.7"
+                    "name": "registry.redhat.io/ubi8/go-toolset:1.16.7"
                 },
-                "name": "1.14.7-ubi8",
+                "name": "1.16.7-ubi8",
                 "referencePolicy": {
                     "type": "Local"
                 }

--- a/imagestreams/golang-rhel-aarch64.json
+++ b/imagestreams/golang-rhel-aarch64.json
@@ -1,5 +1,5 @@
 {
-    "apiVersion": "v1",
+    "apiVersion": "image.openshift.io/v1",
     "kind": "ImageStream",
     "metadata": {
         "annotations": {

--- a/imagestreams/golang-rhel.json
+++ b/imagestreams/golang-rhel.json
@@ -21,7 +21,7 @@
                 },
                 "from": {
                     "kind": "ImageStreamTag",
-                    "name": "1.14.7-ubi8"
+                    "name": "1.16.7-ubi8"
                 },
                 "name": "latest",
                 "referencePolicy": {
@@ -32,7 +32,7 @@
                 "annotations": {
                   "description": "Build and run Go applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.",
                   "iconClass": "icon-go-gopher",
-                  "openshift.io/display-name": "Go 1.14.7 (UBI 8)",
+                  "openshift.io/display-name": "Go 1.16.7 (UBI 8)",
                   "openshift.io/provider-display-name": "Red Hat, Inc.",
                   "sampleRepo": "https://github.com/sclorg/golang-ex.git",
                   "supports": "golang",
@@ -40,9 +40,9 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.redhat.io/ubi8/go-toolset:1.14.7"
+                    "name": "registry.redhat.io/ubi8/go-toolset:1.16.7"
                 },
-                "name": "1.14.7-ubi8",
+                "name": "1.16.7-ubi8",
                 "referencePolicy": {
                     "type": "Local"
                 }
@@ -51,7 +51,7 @@
                 "annotations": {
                   "description": "Build and run Go applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/golang-container/blob/master/README.md.",
                   "iconClass": "icon-go-gopher",
-                  "openshift.io/display-name": "Go 1.13.4 (UBI 7)",
+                  "openshift.io/display-name": "Go 1.16.7 (UBI 7)",
                   "openshift.io/provider-display-name": "Red Hat, Inc.",
                   "sampleRepo": "https://github.com/sclorg/golang-ex.git",
                   "supports": "golang",
@@ -59,9 +59,9 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.redhat.io/ubi7/go-toolset:1.13.4"
+                    "name": "registry.redhat.io/ubi7/go-toolset:1.16.7"
                 },
-                "name": "1.13.4-ubi7",
+                "name": "1.16.7-ubi7",
                 "referencePolicy": {
                     "type": "Local"
                 }

--- a/imagestreams/golang-rhel.json
+++ b/imagestreams/golang-rhel.json
@@ -1,5 +1,5 @@
 {
-    "apiVersion": "v1",
+    "apiVersion": "image.openshift.io/v1",
     "kind": "ImageStream",
     "metadata": {
         "annotations": {


### PR DESCRIPTION
- Update imagestreams for RHEL 8.5 and RHSCL 3.8
- Use groupified apiVersion
