### PR TITLE
Update imagestreams to 1.17.10 (RHEL 7 and 8)

### DIFF
--- a/imagestreams/golang-centos.json
+++ b/imagestreams/golang-centos.json
@@ -59,7 +59,7 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/ubi8/go-toolset:1.17.7"
+                    "name": "registry.access.redhat.com/ubi8/go-toolset:1.17.10"
                 },
                 "name": "1.17-ubi8",
                 "referencePolicy": {
@@ -78,7 +78,7 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/ubi7/go-toolset:1.17.7"
+                    "name": "registry.access.redhat.com/ubi7/go-toolset:1.17.10"
                 },
                 "name": "1.17-ubi7",
                 "referencePolicy": {

--- a/imagestreams/golang-rhel-aarch64.json
+++ b/imagestreams/golang-rhel-aarch64.json
@@ -59,7 +59,7 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.redhat.io/ubi8/go-toolset:1.17.7"
+                    "name": "registry.redhat.io/ubi8/go-toolset:1.17.10"
                 },
                 "name": "1.17-ubi8",
                 "referencePolicy": {

--- a/imagestreams/golang-rhel.json
+++ b/imagestreams/golang-rhel.json
@@ -59,7 +59,7 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.redhat.io/ubi8/go-toolset:1.17.7"
+                    "name": "registry.redhat.io/ubi8/go-toolset:1.17.10"
                 },
                 "name": "1.17-ubi8",
                 "referencePolicy": {
@@ -78,7 +78,7 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.redhat.io/ubi7/go-toolset:1.17.7"
+                    "name": "registry.redhat.io/ubi7/go-toolset:1.17.10"
                 },
                 "name": "1.17-ubi7",
                 "referencePolicy": {


### PR DESCRIPTION
Is 1.17.10 for RHEL 9 forthcoming?  Any progress on 1.17 floating tags?

/cc @alexsaezm

