### PR TITLE
Use floating tags

### DIFF
--- a/imagestreams/golang-centos.json
+++ b/imagestreams/golang-centos.json
@@ -40,7 +40,7 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/ubi9/go-toolset:1.17.7"
+                    "name": "registry.access.redhat.com/ubi9/go-toolset:1.17"
                 },
                 "name": "1.17-ubi9",
                 "referencePolicy": {
@@ -59,7 +59,7 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/ubi8/go-toolset:1.17.10"
+                    "name": "registry.access.redhat.com/ubi8/go-toolset:1.17"
                 },
                 "name": "1.17-ubi8",
                 "referencePolicy": {
@@ -78,7 +78,7 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.access.redhat.com/ubi7/go-toolset:1.17.10"
+                    "name": "registry.access.redhat.com/ubi7/go-toolset:1.17"
                 },
                 "name": "1.17-ubi7",
                 "referencePolicy": {

--- a/imagestreams/golang-rhel-aarch64.json
+++ b/imagestreams/golang-rhel-aarch64.json
@@ -40,7 +40,7 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.redhat.io/ubi9/go-toolset:1.17.7"
+                    "name": "registry.redhat.io/ubi9/go-toolset:1.17"
                 },
                 "name": "1.17-ubi9",
                 "referencePolicy": {
@@ -59,7 +59,7 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.redhat.io/ubi8/go-toolset:1.17.10"
+                    "name": "registry.redhat.io/ubi8/go-toolset:1.17"
                 },
                 "name": "1.17-ubi8",
                 "referencePolicy": {

--- a/imagestreams/golang-rhel.json
+++ b/imagestreams/golang-rhel.json
@@ -40,7 +40,7 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.redhat.io/ubi9/go-toolset:1.17.7"
+                    "name": "registry.redhat.io/ubi9/go-toolset:1.17"
                 },
                 "name": "1.17-ubi9",
                 "referencePolicy": {
@@ -59,7 +59,7 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.redhat.io/ubi8/go-toolset:1.17.10"
+                    "name": "registry.redhat.io/ubi8/go-toolset:1.17"
                 },
                 "name": "1.17-ubi8",
                 "referencePolicy": {
@@ -78,7 +78,7 @@
                 },
                 "from": {
                     "kind": "DockerImage",
-                    "name": "registry.redhat.io/ubi7/go-toolset:1.17.10"
+                    "name": "registry.redhat.io/ubi7/go-toolset:1.17"
                 },
                 "name": "1.17-ubi7",
                 "referencePolicy": {


### PR DESCRIPTION
Now that the ubi/rhel images have the floating tags configure, I took the liberty to update the references so we don't need to update them constantly.

Fix #42 